### PR TITLE
Bug/ie9 styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The following props can be used to modify the HUD's style and/or behaviour:
 |---|---|---|---|---|
 |__`isVisible`__|_Boolean_|Required|`N/A`|Displays the HUD when set to true.
 |__`clickHandler`__|_Function_|Optional|`() => {}`|Sets a clickHandler on the `ProgressHUD`.
-|__`overlayColor`__|_String_|Optional|`rgba(0, 0, 0, 0)`|Sets the color of the overlay.
+|__`overlayColor`__|_String_|Optional|`rgb(0, 0, 0)`|Sets the color of the overlay.
+|__`overlayOpacity`__|_String_|Optional|`0.5`|Sets the opacity of the overlay.
 |__`color`__|_String_|Optional|`#000`|Sets the color of the spinner.
 
 ## License

--- a/src/components/progress-hud.js
+++ b/src/components/progress-hud.js
@@ -8,12 +8,14 @@ const propTypes = {
   clickHandler: PropTypes.func,
   color: PropTypes.string,
   isVisible: PropTypes.bool.isRequired,
-  overlayColor: PropTypes.string
+  overlayColor: PropTypes.string,
+  overlayOpacity: PropTypes.string
 };
 const defaultProps = {
   clickHandler: () => {},
   color: "#000",
-  overlayColor: "rgba(0, 0, 0, 0)"
+  overlayColor: "rgb(0, 0, 0)",
+  overlayOpacity: "0.5"
 };
 
 export default class ProgressHUD extends Component {
@@ -43,7 +45,9 @@ export default class ProgressHUD extends Component {
           style={Object.assign(
             styles.overlay,
             {
-              backgroundColor: this.props.overlayColor
+              backgroundColor: this.props.overlayColor,
+              filter: `alpha(opacity=${this.props.overlayOpacity * 100})`,
+              opacity: this.props.overlayOpacity
             }
           )}
           onClick={this.props.clickHandler}
@@ -56,10 +60,10 @@ export default class ProgressHUD extends Component {
                 style={Object.assign(
                   styles.spinner,
                   {
-                    webkitTransform: `rotate(${interpolated.val}deg)`,
+                    backgroundColor: this.props.color,
                     msTransform: `rotate(${interpolated.val}deg)`,
-                    transform: `rotate(${interpolated.val}deg)`,
-                    backgroundColor: this.props.color
+                    WebkitTransform: `rotate(${interpolated.val}deg)`,
+                    transform: `rotate(${interpolated.val}deg)`
                   }
                 )}
               >

--- a/src/components/progress-hud.js
+++ b/src/components/progress-hud.js
@@ -56,13 +56,20 @@ export default class ProgressHUD extends Component {
                 style={Object.assign(
                   styles.spinner,
                   {
-                    "-ms-transform": `rotate(${interpolated.val}deg)`,
+                    webkitTransform: `rotate(${interpolated.val}deg)`,
+                    msTransform: `rotate(${interpolated.val}deg)`,
                     transform: `rotate(${interpolated.val}deg)`,
                     backgroundColor: this.props.color
                   }
                 )}
               >
                 <img src={`data:image/png;base64,${images["1x"]}`} />
+                <div
+                  style={Object.assign(
+                    styles.curve,
+                    { backgroundColor: this.props.color }
+                  )}
+                />
                 <div style={styles.inner_spinner} />
               </div>
             }

--- a/src/components/progress-hud.js
+++ b/src/components/progress-hud.js
@@ -43,7 +43,7 @@ export default class ProgressHUD extends Component {
           style={Object.assign(
             styles.overlay,
             {
-              backgroundColor: this.props.overlayColor,
+              backgroundColor: this.props.overlayColor
             }
           )}
           onClick={this.props.clickHandler}
@@ -56,7 +56,7 @@ export default class ProgressHUD extends Component {
                 style={Object.assign(
                   styles.spinner,
                   {
-                    '-ms-transform': `rotate(${interpolated.val}deg)`,
+                    "-ms-transform": `rotate(${interpolated.val}deg)`,
                     transform: `rotate(${interpolated.val}deg)`,
                     backgroundColor: this.props.color
                   }

--- a/src/components/progress-hud.js
+++ b/src/components/progress-hud.js
@@ -32,35 +32,37 @@ export default class ProgressHUD extends Component {
     return (
       // jshint ignore:start
       <div
-        key="ProgressHUD"
         style={Object.assign(
-          styles.overlay,
-          {
-            backgroundColor: this.props.overlayColor,
-            display: this.props.isVisible ? "flex" : "none"
+          styles.container, {
+            display: this.props.isVisible ? "block" : "none"
           }
         )}
-        onClick={this.props.clickHandler}
       >
-        <div style={styles.container}>
+        <div
+          key="ProgressHUD"
+          style={Object.assign(
+            styles.overlay,
+            {
+              backgroundColor: this.props.overlayColor,
+            }
+          )}
+          onClick={this.props.clickHandler}
+        >
+        </div>
+        <div style={styles.content}>
           <Spring defaultValue={{ val: 0 }} endValue={this._getEndValue}>
             {interpolated =>
               <div
                 style={Object.assign(
                   styles.spinner,
                   {
+                    '-ms-transform': `rotate(${interpolated.val}deg)`,
                     transform: `rotate(${interpolated.val}deg)`,
                     backgroundColor: this.props.color
                   }
                 )}
               >
                 <img src={`data:image/png;base64,${images["1x"]}`} />
-                <div
-                  style={Object.assign(
-                    styles.curve,
-                    { backgroundColor: this.props.color }
-                  )}
-                />
                 <div style={styles.inner_spinner} />
               </div>
             }

--- a/src/components/progress-hud.js
+++ b/src/components/progress-hud.js
@@ -46,7 +46,6 @@ export default class ProgressHUD extends Component {
             styles.overlay,
             {
               backgroundColor: this.props.overlayColor,
-              filter: `alpha(opacity=${this.props.overlayOpacity * 100})`,
               opacity: this.props.overlayOpacity
             }
           )}

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,38 +1,37 @@
 const styles = {
-  overlay: {
-    zoom: 1,
-    filter: alpha(opacity = 50),
-    opacity: 0.5,
-    display: "block",
+  container: {
     position: "fixed",
-    // display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    // flex: 1,
     top: 0,
     left: 0,
     right: 0,
-    bottom: 0,
+    bottom: 0
+  },
+  overlay: {
+    position: "absolute",
+    width: "100%",
+    height: "100%",
+    filter: "alpha(opacity = 50)",
     zIndex: 2147483647
   },
-  container: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
+  content: {
+    position: "absolute",
+    display: "block",
     width: 100,
     height: 100,
     borderRadius: 16,
-    backgroundColor: "#fff"
+    backgroundColor: "#fff",
+    top: "calc(50% - 50px)",
+    left: "calc(50% - 50px)",
+    zIndex: 2147483648
   },
   spinner: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    position: "relative",
+    position: "absolute",
     width: 50,
     height: 50,
     borderRadius: 50 / 2,
-    backgroundColor: "#000"
+    backgroundColor: "#000",
+    top: "calc(50% - 25px)",
+    left: "calc(50% - 25px)"
   },
   inner_spinner: {
     position: "absolute",
@@ -42,14 +41,6 @@ const styles = {
     height: 42,
     borderRadius: 42 / 2,
     backgroundColor: "#fff"
-  },
-  curve: {
-    position: "absolute",
-    left: 23,
-    width: 4,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: "#000"
   }
 };
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,10 +1,14 @@
 const styles = {
   overlay: {
+    zoom: 1,
+    filter: alpha(opacity = 50),
+    opacity: 0.5,
+    display: "block",
     position: "fixed",
-    display: "flex",
+    // display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    flex: 1,
+    // flex: 1,
     top: 0,
     left: 0,
     right: 0,

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,8 +1,8 @@
 const styles = {
   container: {
     position: "fixed",
-    top: 0,
     left: 0,
+    top: 0,
     right: 0,
     bottom: 0
   },
@@ -15,23 +15,23 @@ const styles = {
   },
   content: {
     position: "absolute",
+    left: "calc(50% - 50px)",
+    top: "calc(50% - 50px)",
     display: "block",
     width: 100,
     height: 100,
     borderRadius: 16,
     backgroundColor: "#fff",
-    top: "calc(50% - 50px)",
-    left: "calc(50% - 50px)",
     zIndex: 2147483648
   },
   spinner: {
     position: "absolute",
+    left: "calc(50% - 25px)",
+    top: "calc(50% - 25px)",
     width: 50,
     height: 50,
     borderRadius: 50 / 2,
-    backgroundColor: "#000",
-    top: "calc(50% - 25px)",
-    left: "calc(50% - 25px)"
+    backgroundColor: "#000"
   },
   inner_spinner: {
     position: "absolute",
@@ -41,6 +41,15 @@ const styles = {
     height: 42,
     borderRadius: 42 / 2,
     backgroundColor: "#fff"
+  },
+  curve: {
+    position: "absolute",
+    left: 23,
+    top: 0,
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "#000"
   }
 };
 


### PR DESCRIPTION
### Overview
- Adds css support for IE9 - removes flex and rgba in favor of positioning and opacity.
- Separates overlayColor prop into overlayColor and overlayOpacity.
### IE9 Screenshot

<img width="532" alt="screen shot 2015-09-10 at 12 18 12 pm" src="https://cloud.githubusercontent.com/assets/3689921/9793916/124d7b94-57b6-11e5-8193-6d2bb4e43d27.png">
### Tests
- [x] IE9 (obviously)
- [x] IE10
- [x] IE11
- [x] Firefox
- [x] Safari
- [x] Chrome
